### PR TITLE
Add 3.8 + ember-decorators-polyfill CI job.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ jobs:
     - env: EMBER_TRY_SCENARIO=ember-lts-2.18
     - env: EMBER_TRY_SCENARIO=ember-lts-3.4
     - env: EMBER_TRY_SCENARIO=ember-lts-3.8
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.8-with-decorators
     - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -56,6 +56,15 @@ module.exports = function() {
           }
         },
         {
+          name: 'ember-lts-3.8-with-decorators',
+          npm: {
+            devDependencies: {
+              'ember-source': '~3.8.0',
+              'ember-decorators-polyfill': '^1.0.0'
+            }
+          }
+        },
+        {
           name: 'ember-release',
           npm: {
             devDependencies: {


### PR DESCRIPTION
This failed prior to the changes made in https://github.com/pzuraq/ember-decorators-polyfill/pull/21 which was released as 1.0.6. I figured it would be nice to get this on CI to make sure we consider 3.8 + the polyfill in future refactors.