### PR TITLE
Updated isHTMLSafe import, fixes #698

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@
 /.node_modules.ember-try/
 /bower.json.ember-try
 /package.json.ember-try
+
+# IDE
+/.idea/
+/.vscode/
+/.history/

--- a/addon/utils/utils.js
+++ b/addon/utils/utils.js
@@ -1,7 +1,7 @@
 import ArrayProxy from '@ember/array/proxy';
 import ObjectProxy from '@ember/object/proxy';
 import { assign } from '@ember/polyfills';
-import { isHTMLSafe } from '@ember/string';
+import { isHTMLSafe } from '@ember/template';
 import EmberObject, { get } from '@ember/object';
 import { typeOf } from '@ember/utils';
 import { A as emberArray, isArray } from '@ember/array';


### PR DESCRIPTION
Resolves #698.

Changes proposed:

 - Update the `isHTMLSafe` import to use the [new import path](https://api.emberjs.com/ember/release/functions/@ember/template/isHTMLSafe).

Tasks:

- Testing
    - [x] ~~Added test case(s)~~ Already covered by exisisting test cases
    - [ ] Udpate test matrix maybe?
- Documentation
    - [ ] Update EmberJS version requirement
    - [ ] Add note for support of older Ember versions (e. g. use an older version of the addon or add a polyfill?)

CC @simonihmig 
