### PR TITLE
Update addon to work with Ember 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:ember-compatibility": "ember try:each"
   },
   "engines": {
-    "node": "12.* || 14.* || >= 16"
+    "node": "14.* || >= 16"
   },
   "contributors": [
     {

--- a/tests/acceptance/dummy-index-test.js
+++ b/tests/acceptance/dummy-index-test.js
@@ -1,7 +1,6 @@
 import { click, fillIn, find, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-import { dasherize } from '@ember/string';
 
 const validInputValues = {
   username: 'offirgolan',
@@ -44,19 +43,22 @@ module('Acceptance | Dummy | index', function (hooks) {
   });
 
   test('Valid form submit', async function (assert) {
+    assert.expect(16);
     await visit('/');
 
     for (let key in validInputValues) {
-      const selector = `[data-test-${dasherize(key)}]`;
-      const input = find(`${selector} input`);
+      const selector = `input[name='${key}']`;
+      const input = find(selector);
 
       assert.ok(input, `${selector} found`);
       await fillIn(input, validInputValues[key]);
-      assert.dom(selector).hasClass('has-success');
+      assert.ok(
+        find(selector).closest('.has-success'),
+        `${selector} has the class 'has-success'`
+      );
     }
 
     await click('[data-test-sign-up]');
-    // assert.dom('[data-test-tomster]').exists();
     assert.dom('.form .registered .icon-success').exists();
     assert.dom('.form .registered h2.success').hasText('Success');
   });
@@ -64,18 +66,24 @@ module('Acceptance | Dummy | index', function (hooks) {
   test('Invalid to valid email', async function (assert) {
     assert.expect(4);
     await visit('/');
-
-    const input = find('[data-test-email] input');
+    const selector = `input[name='email']`;
+    const input = find(selector);
 
     assert.ok(input);
     await fillIn(input, 'invalid-email');
 
-    assert.dom('[data-test-email]').hasClass('has-error');
+    assert.ok(
+      find(selector).closest('.has-error'),
+      `${selector} has the class 'has-error'`
+    );
     assert
-      .dom('[data-test-email] .input-error')
+      .dom(`${selector} ~ .input-error`)
       .hasText('This field must be a valid email address');
 
     await fillIn(input, validInputValues.email);
-    assert.dom('[data-test-email]').hasClass('has-success');
+    assert.ok(
+      find(selector).closest('.has-success'),
+      `${selector} has the class 'has-success'`
+    );
   });
 });


### PR DESCRIPTION
Resolves #701

Changes proposed:

 - Update v-get.js to functional syntax for compatability with ember 4.0+
 - Update import for htmlSafe (`@ember/string` => `@ember/template`)
 - Fix acceptance tests failing due to missing selectors