### PR TITLE
Updated ember required and ember validators packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v4.0.0
+
+- [[Major]: Remove Moment and Node 10](https://github.com/offirgolan/ember-validators/pull/100);
+  - Remove Node 10 minimum requirement in favor of Node 12
+  - removed custom String 'now' argument.
+  - remove momentjs
+  - Remove `precision` argument.  If you need to compare based on precision, you can use the Intl.DateTimeFormat [APIs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat#using_options) to hone in on the comparison - `{ year: 'numeric' }`
+  - Added `locale` option. Defaults to en-us when creating date times using `Intl.DateTimeFormat` API.
+
 ## v4.0.0-beta.10
 
 - [#668](https://github.com/adopted-ember-addons/ember-cp-validations/pull/668) Support Ember 3.13 [@jrjohnson](https://github.com/jrjohnson)

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "ember-cli-babel": "^7.26.10",
     "ember-require-module": "^0.4.0",
-    "ember-validators": "^3.0.1"
+    "ember-validators": "^4.1.1"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",

--- a/tests/dummy/app/models/user-detail.js
+++ b/tests/dummy/app/models/user-detail.js
@@ -14,7 +14,7 @@ const Validations = buildValidations(
       validators: [
         validator('presence', true),
         validator('date', {
-          before: 'now',
+          before: new Date(),
           after: computed(function () {
             return moment().subtract(120, 'years').format('M/D/YYYY');
           }).volatile(),

--- a/tests/unit/validators/date-test.js
+++ b/tests/unit/validators/date-test.js
@@ -24,7 +24,7 @@ module('Unit | Validator | date', function (hooks) {
 
     options = {
       allowBlank: true,
-      before: '1/1/2015',
+      before: new Date('1/1/2015'),
     };
 
     builtOptions = validator.buildOptions(options);
@@ -33,7 +33,7 @@ module('Unit | Validator | date', function (hooks) {
     assert.true(message);
 
     message = validator.validate('1/1/2016', builtOptions.toObject());
-    assert.equal(message, 'This field must be before Jan 1st, 2015');
+    assert.equal(message, 'This field must be before January 1, 2015');
   });
 
   test('valid date', function (assert) {
@@ -54,15 +54,18 @@ module('Unit | Validator | date', function (hooks) {
     assert.expect(2);
 
     options = {
-      format: 'DD/M/YYYY',
+      format: { year: 'numeric', month: 'numeric', day: '2-digit' },
     };
 
     builtOptions = validator.buildOptions(options);
 
     message = validator.validate('27/3/15', builtOptions.toObject());
-    assert.equal(message, 'This field must be in the format of DD/M/YYYY');
+    assert.equal(message, 'This field must be a valid date');
 
-    message = validator.validate('27/3/2015', builtOptions.toObject());
+    message = validator.validate(
+      new Date('3/27/2015'),
+      builtOptions.toObject()
+    );
     assert.true(message);
   });
 
@@ -90,7 +93,7 @@ module('Unit | Validator | date', function (hooks) {
     builtOptions = validator.buildOptions(options);
 
     message = validator.validate('1/1/2016', builtOptions.toObject());
-    assert.equal(message, 'This field must be before Jan 1st, 2015');
+    assert.equal(message, 'This field must be before January 1, 2015');
 
     message = validator.validate('1/1/2014', builtOptions.toObject());
     assert.true(message);
@@ -98,9 +101,13 @@ module('Unit | Validator | date', function (hooks) {
 
   test('before now', function (assert) {
     assert.expect(2);
-    let now = moment().format('MMM Do, YYYY');
+    let now = new Intl.DateTimeFormat('en', { dateStyle: 'long' }).format(
+      new Date('1/1/3015')
+    );
     options = {
-      before: 'now',
+      before: new Intl.DateTimeFormat('en', { dateStyle: 'long' }).format(
+        new Date('1/1/3015')
+      ),
     };
 
     builtOptions = validator.buildOptions(options);
@@ -122,7 +129,7 @@ module('Unit | Validator | date', function (hooks) {
     builtOptions = validator.buildOptions(options);
 
     message = validator.validate('1/1/2016', builtOptions.toObject());
-    assert.equal(message, 'This field must be on or before Jan 1st, 2015');
+    assert.equal(message, 'This field must be on or before January 1, 2015');
 
     message = validator.validate('1/1/2014', builtOptions.toObject());
     assert.true(message);
@@ -133,20 +140,25 @@ module('Unit | Validator | date', function (hooks) {
 
   test('before now or on', function (assert) {
     assert.expect(3);
-    let now = moment().format('MMM Do, YYYY');
+    let now = new Date();
     options = {
-      onOrBefore: 'now',
+      onOrBefore: new Date(),
     };
 
     builtOptions = validator.buildOptions(options);
 
-    message = validator.validate('1/1/3015', builtOptions.toObject());
-    assert.equal(message, `This field must be on or before ${now}`);
+    message = validator.validate(new Date('1/1/3015'), builtOptions.toObject());
+    assert.equal(
+      message,
+      `This field must be on or before ${new Intl.DateTimeFormat('en', {
+        dateStyle: 'long',
+      }).format(now)}`
+    );
 
-    message = validator.validate('1/1/2014', builtOptions.toObject());
+    message = validator.validate(new Date('1/1/2014'), builtOptions.toObject());
     assert.true(message);
 
-    message = validator.validate('now', builtOptions.toObject());
+    message = validator.validate(now, builtOptions.toObject());
     assert.true(message);
   });
 
@@ -162,9 +174,11 @@ module('Unit | Validator | date', function (hooks) {
     ];
 
     assert.expect(precisions.length * 3 - 1);
-    let now = moment(new Date('2013-02-08T09:30:26'));
+    let now = new Date('2013-02-08T09:30:26');
     let dateString = now.toString();
-    let nowMessage = now.format('MMM Do, YYYY');
+    let nowMessage = new Intl.DateTimeFormat('en', {
+      dateStyle: 'long',
+    }).format(now);
 
     for (let i = 0; i < precisions.length; i++) {
       let precision = precisions[i];
@@ -199,13 +213,13 @@ module('Unit | Validator | date', function (hooks) {
     assert.expect(2);
 
     options = {
-      after: '1/1/2015',
+      after: new Date('1/1/2015'),
     };
 
     builtOptions = validator.buildOptions(options);
 
     message = validator.validate('1/1/2014', builtOptions.toObject());
-    assert.equal(message, 'This field must be after Jan 1st, 2015');
+    assert.equal(message, 'This field must be after January 1, 2015');
 
     message = validator.validate('1/1/2016', builtOptions.toObject());
     assert.true(message);
@@ -213,9 +227,9 @@ module('Unit | Validator | date', function (hooks) {
 
   test('after now', function (assert) {
     assert.expect(2);
-    let now = moment().format('MMM Do, YYYY');
+    let now = new Intl.DateTimeFormat('en', { dateStyle: 'long' }).format();
     options = {
-      after: 'now',
+      after: new Date(),
     };
 
     builtOptions = validator.buildOptions(options);
@@ -231,13 +245,13 @@ module('Unit | Validator | date', function (hooks) {
     assert.expect(3);
 
     options = {
-      onOrAfter: '1/1/2015',
+      onOrAfter: new Date('1/1/2015'),
     };
 
     builtOptions = validator.buildOptions(options);
 
     message = validator.validate('1/1/2014', builtOptions.toObject());
-    assert.equal(message, 'This field must be on or after Jan 1st, 2015');
+    assert.equal(message, 'This field must be on or after January 1, 2015');
 
     message = validator.validate('1/1/2016', builtOptions.toObject());
     assert.true(message);
@@ -248,9 +262,9 @@ module('Unit | Validator | date', function (hooks) {
 
   test('after now or on', function (assert) {
     assert.expect(3);
-    let now = moment().format('MMM Do, YYYY');
+    let now = new Intl.DateTimeFormat('en', { dateStyle: 'long' }).format();
     options = {
-      onOrAfter: 'now',
+      onOrAfter: new Intl.DateTimeFormat('en', { dateStyle: 'long' }).format(),
       precision: 'second',
     };
 
@@ -262,7 +276,7 @@ module('Unit | Validator | date', function (hooks) {
     message = validator.validate('1/1/3015', builtOptions.toObject());
     assert.true(message);
 
-    message = validator.validate('now', builtOptions.toObject());
+    message = validator.validate(now, builtOptions.toObject());
     assert.true(message);
   });
 
@@ -278,9 +292,11 @@ module('Unit | Validator | date', function (hooks) {
     ];
 
     assert.expect(precisions.length * 3 - 1);
-    let now = moment(new Date('2013-02-08T09:30:26'));
+    let now = new Date('2013-02-08T09:30:26');
     let dateString = now.toString();
-    let nowMessage = now.format('MMM Do, YYYY');
+    let nowMessage = new Intl.DateTimeFormat('en', {
+      dateStyle: 'long',
+    }).format(now);
 
     for (let i = 0; i < precisions.length; i++) {
       let precision = precisions[i];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1966,11 +1966,7 @@
     ember-cli-version-checker "^5.1.2"
     semver "^7.3.5"
 
-<<<<<<< HEAD
-"@embroider/macros@1.8.0", "@embroider/macros@^0.50.0 || ^1.0.0", "@embroider/macros@^1.6.0":
-=======
 "@embroider/macros@1.8.0", "@embroider/macros@^0.50.0 || ^1.0.0", "@embroider/macros@^1.0.0", "@embroider/macros@^1.6.0":
->>>>>>> bf1481a... reset lock file
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-1.8.0.tgz#9e947e6292f0d7768a0f743d883c3e794457eaec"
   integrity sha512-jeRoUMPbZ/ADBU0FsyBGS1UgV5vQmwIPnpbVUsJ0XcZFZq/8ZHV6Ts4yeubvH/lePnUpHaKogs4dDvGk5tpQKw==
@@ -1984,23 +1980,6 @@
     resolve "^1.20.0"
     semver "^7.3.2"
 
-<<<<<<< HEAD
-"@embroider/macros@^1.0.0":
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-1.8.3.tgz#2f0961ab8871f6ad819630208031d705b357757e"
-  integrity sha512-gnIOfTL/pUkoD6oI7JyWOqXlVIUgZM+CnbH10/YNtZr2K0hij9eZQMdgjOZZVgN0rKOFw9dIREqc1ygrJHRYQA==
-  dependencies:
-    "@embroider/shared-internals" "1.8.3"
-    assert-never "^1.2.1"
-    babel-import-util "^1.1.0"
-    ember-cli-babel "^7.26.6"
-    find-up "^5.0.0"
-    lodash "^4.17.21"
-    resolve "^1.20.0"
-    semver "^7.3.2"
-
-=======
->>>>>>> bf1481a... reset lock file
 "@embroider/shared-internals@1.8.0", "@embroider/shared-internals@^1.0.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@embroider/shared-internals/-/shared-internals-1.8.0.tgz#4c9b563e5f155410d982a30667b027a227be7312"
@@ -6092,11 +6071,7 @@ ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.1:
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.1.tgz#5016b80cdef37036c4282eef2d863e1d73576879"
   integrity sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw==
 
-<<<<<<< HEAD
-ember-cli-babel@^6.6.0:
-=======
 ember-cli-babel@^6.6.0, ember-cli-babel@^6.9.2:
->>>>>>> bf1481a... reset lock file
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
   integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==
@@ -6688,8 +6663,6 @@ ember-qunit@^5.1.5:
     silent-error "^1.1.1"
     validate-peer-dependencies "^1.2.0"
 
-<<<<<<< HEAD
-=======
 ember-require-module@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/ember-require-module/-/ember-require-module-0.3.0.tgz#65aff7908b5b846467e4526594d33cfe0c23456b"
@@ -6697,7 +6670,6 @@ ember-require-module@^0.3.0:
   dependencies:
     ember-cli-babel "^6.9.2"
 
->>>>>>> bf1481a... reset lock file
 ember-require-module@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/ember-require-module/-/ember-require-module-0.4.0.tgz#2f86bae244f70c3d4cb8b9ef8abbd617e7a95218"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1966,7 +1966,11 @@
     ember-cli-version-checker "^5.1.2"
     semver "^7.3.5"
 
+<<<<<<< HEAD
+"@embroider/macros@1.8.0", "@embroider/macros@^0.50.0 || ^1.0.0", "@embroider/macros@^1.6.0":
+=======
 "@embroider/macros@1.8.0", "@embroider/macros@^0.50.0 || ^1.0.0", "@embroider/macros@^1.0.0", "@embroider/macros@^1.6.0":
+>>>>>>> bf1481a... reset lock file
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-1.8.0.tgz#9e947e6292f0d7768a0f743d883c3e794457eaec"
   integrity sha512-jeRoUMPbZ/ADBU0FsyBGS1UgV5vQmwIPnpbVUsJ0XcZFZq/8ZHV6Ts4yeubvH/lePnUpHaKogs4dDvGk5tpQKw==
@@ -1980,6 +1984,23 @@
     resolve "^1.20.0"
     semver "^7.3.2"
 
+<<<<<<< HEAD
+"@embroider/macros@^1.0.0":
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-1.8.3.tgz#2f0961ab8871f6ad819630208031d705b357757e"
+  integrity sha512-gnIOfTL/pUkoD6oI7JyWOqXlVIUgZM+CnbH10/YNtZr2K0hij9eZQMdgjOZZVgN0rKOFw9dIREqc1ygrJHRYQA==
+  dependencies:
+    "@embroider/shared-internals" "1.8.3"
+    assert-never "^1.2.1"
+    babel-import-util "^1.1.0"
+    ember-cli-babel "^7.26.6"
+    find-up "^5.0.0"
+    lodash "^4.17.21"
+    resolve "^1.20.0"
+    semver "^7.3.2"
+
+=======
+>>>>>>> bf1481a... reset lock file
 "@embroider/shared-internals@1.8.0", "@embroider/shared-internals@^1.0.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@embroider/shared-internals/-/shared-internals-1.8.0.tgz#4c9b563e5f155410d982a30667b027a227be7312"
@@ -6071,7 +6092,11 @@ ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.1:
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.1.tgz#5016b80cdef37036c4282eef2d863e1d73576879"
   integrity sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw==
 
+<<<<<<< HEAD
+ember-cli-babel@^6.6.0:
+=======
 ember-cli-babel@^6.6.0, ember-cli-babel@^6.9.2:
+>>>>>>> bf1481a... reset lock file
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
   integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==
@@ -6663,6 +6688,8 @@ ember-qunit@^5.1.5:
     silent-error "^1.1.1"
     validate-peer-dependencies "^1.2.0"
 
+<<<<<<< HEAD
+=======
 ember-require-module@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/ember-require-module/-/ember-require-module-0.3.0.tgz#65aff7908b5b846467e4526594d33cfe0c23456b"
@@ -6670,6 +6697,7 @@ ember-require-module@^0.3.0:
   dependencies:
     ember-cli-babel "^6.9.2"
 
+>>>>>>> bf1481a... reset lock file
 ember-require-module@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/ember-require-module/-/ember-require-module-0.4.0.tgz#2f86bae244f70c3d4cb8b9ef8abbd617e7a95218"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6071,7 +6071,7 @@ ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.1:
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.1.tgz#5016b80cdef37036c4282eef2d863e1d73576879"
   integrity sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw==
 
-ember-cli-babel@^6.6.0, ember-cli-babel@^6.9.2:
+ember-cli-babel@^6.6.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
   integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==
@@ -6663,13 +6663,6 @@ ember-qunit@^5.1.5:
     silent-error "^1.1.1"
     validate-peer-dependencies "^1.2.0"
 
-ember-require-module@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/ember-require-module/-/ember-require-module-0.3.0.tgz#65aff7908b5b846467e4526594d33cfe0c23456b"
-  integrity sha512-rYN4YoWbR9VlJISSmx0ZcYZOgMcXZLGR7kdvp3zDerjIvYmHm/3p+K56fEAYmJILA6W4F+cBe41Tq2HuQAZizA==
-  dependencies:
-    ember-cli-babel "^6.9.2"
-
 ember-require-module@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/ember-require-module/-/ember-require-module-0.4.0.tgz#2f86bae244f70c3d4cb8b9ef8abbd617e7a95218"
@@ -6825,13 +6818,13 @@ ember-try@^1.4.0:
     rsvp "^4.7.0"
     walk-sync "^1.1.3"
 
-ember-validators@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/ember-validators/-/ember-validators-3.0.1.tgz#9e0f7ed4ce6817aa05f7d46e95a0267c03f1f043"
-  integrity sha512-GbvvECDG9N7U+4LXxPWNgiSnGbOzgvGBIxtS4kw2uyEIy7kymtgszhpSnm8lGMKYnhCKBqFingh8qnVKlCi0lg==
+ember-validators@^4.1.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/ember-validators/-/ember-validators-4.1.2.tgz#e70c0ac80f6b66c8288ffe5860c96e81bf621691"
+  integrity sha512-aNyJW52eWvWhdcRfnb0pGYSDuQU4i4XjA682aDG1ocmz7eUEDw7bXXvKEYGtVsPTtPLtUPvTtaH9mXKpMG+1xA==
   dependencies:
-    ember-cli-babel "^6.9.2"
-    ember-require-module "^0.3.0"
+    "@embroider/macros" "^1.0.0"
+    ember-cli-babel "^7.26.11"
 
 emit-function@0.0.2:
   version "0.0.2"


### PR DESCRIPTION
Resolves # 

 - To get the updated version of `ember-cli-babel` which is causing depreciation warnings
 
 
<img width="1609" alt="Screenshot 2022-03-02 at 4 23 09 PM" src="https://user-images.githubusercontent.com/10308692/156396404-2782ac56-7c8f-434b-b9cb-b2a67bb24b47.png">

 
Changes proposed:

 - Updating `ember-validators` as it's current version is already having updated babel version
 

Tasks:

- [ ] Added test case(s)
- [ ] Updated documentation
