### PR TITLE
Replace travis with github actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ember CP Validations
 
-[![Build Status](https://travis-ci.org/adopted-ember-addons/ember-cp-validations.svg?branch=master)](https://travis-ci.org/adopted-ember-addons/ember-cp-validations)
+[![Build Status](https://github.com/adopted-ember-addons/ember-cp-validations/actions/workflows/ci.yml/badge.svg)](https://github.com/adopted-ember-addons/ember-cp-validations/actions/workflows/ci.yml)
 [![npm version](https://badge.fury.io/js/ember-cp-validations.svg)](http://badge.fury.io/js/ember-cp-validations)
 [![Download Total](https://img.shields.io/npm/dt/ember-cp-validations.svg)](http://badge.fury.io/js/ember-cp-validations)
 [![Ember Observer Score](http://emberobserver.com/badges/ember-cp-validations.svg)](http://emberobserver.com/addons/ember-cp-validations)


### PR DESCRIPTION
@MelSumner can you remove the required Travis CI check:

<img width="859" alt="Bildschirmfoto 2022-08-17 um 20 04 45" src="https://user-images.githubusercontent.com/54812/185210894-3346f10c-01e4-463e-a9ad-ccf14249c74a.png">
