### PR TITLE
fix(date): Restore 'format', 'precison', and usage of `moment` for the date validator

### DIFF
--- a/addon/validators/date.js
+++ b/addon/validators/date.js
@@ -3,6 +3,23 @@ import moment from 'moment';
 import EmberValidator from 'ember-cp-validations/-private/ember-validator';
 
 /**
+ * @typedef {'now'|string|null|moment.Moment|Date} ReferenceDate
+ */
+
+/**
+ * @typedef {object} DateValidatorOptions
+ * @property {boolean} [allowNone] If true, skips validation if the value is "none", according to Ember.
+ * @property {boolean} [allowBlank] If true, skips validation if the value is "empty," according to Ember.
+ * @property {string} [format] If provided, validates that a string value is in this format.
+ * @property {ReferenceDate} [before] The value must be before this date.
+ * @property {ReferenceDate} [onOrBefore] The value must be on or before this date.
+ * @property {ReferenceDate} [after] The value must be after this date.
+ * @property {ReferenceDate} [onOrAfter] The value must be on or after this date.
+ * @property {'year'|'month'|'week'|'day'|'hour'|'minute'|'second'|'millisecond'} [precision] The granularity of the comparison between a reference date and the value. If the difference is less than the precision, the values are considered equivalent.
+ * @property {string} [errorFormat] The format used to display the reference date in validation errors. Defaults to `MMM Do, YYYY`.
+ */
+
+/**
  *  <i class="fa fa-hand-o-right" aria-hidden="true"></i> [See All Options](#method_validate)
  *
  *  Validate over a date range. Uses [MomentJS](http://momentjs.com/) for date mathematics and calculations.
@@ -34,7 +51,7 @@ export default EmberValidator.extend({
    * A reimplementation of the v2 Date validator from ember-validators, since v3 removed support for most
    * desired validation errors.
    * @param {any} value A string, null, or moment object
-   * @param {Record<string, string|moment|boolean>} options
+   * @param {DateValidatorOptions} options
    * @returns {true|string} true if passed, otherwise the error message
    */
   validate(value, options) {

--- a/addon/validators/date.js
+++ b/addon/validators/date.js
@@ -1,3 +1,5 @@
+import { isEmpty, isNone } from '@ember/utils';
+import moment from 'moment';
 import EmberValidator from 'ember-cp-validations/-private/ember-validator';
 
 /**
@@ -27,4 +29,88 @@ import EmberValidator from 'ember-cp-validations/-private/ember-validator';
  */
 export default EmberValidator.extend({
   _evType: 'date',
+
+  /**
+   * A reimplementation of the v2 Date validator from ember-validators, since v3 removed support for most
+   * desired validation errors.
+   * @param {any} value A string, null, or moment object
+   * @param {Record<string, string|moment|boolean>} options
+   * @returns {true|string} true if passed, otherwise the error message
+   */
+  validate(value, options) {
+    if (options.allowNone && isNone(value)) return true;
+    if (options.allowBlank && isEmpty(value)) return true;
+
+    const hasFormat = Boolean(options.format);
+
+    // Parse the value. If a format was given, the input must be in that format.
+    const parsed = hasFormat
+      ? moment(value, options.format, true)
+      : moment(value);
+    if (!parsed.isValid()) {
+      // If a format was given, reparse to determine whether we received something that represented a date-ish.
+      // If so, then raise a 'wrongFormatError'. Otherwise, raise a date error.
+      if (
+        hasFormat &&
+        (moment(value, options.format).isValid() || moment(value).isValid())
+      ) {
+        return this.createErrorMessage('wrongDateFormat', value, options);
+      }
+      return this.createErrorMessage('date', value, options);
+    }
+
+    // Validate all provided relational requirements are satisfied. If the
+    // reference value is not currently valid, the validation will fail.
+    const errorFormat = options.errorFormat || 'MMM Do, YYYY';
+    const { precision } = options;
+    const getRelation = (key) => {
+      if (options[key] === 'now') return moment.utc();
+      return moment(options[key], options.format, hasFormat);
+    };
+    if (typeof options.before !== 'undefined') {
+      const reference = getRelation('before');
+
+      if (!parsed.isBefore(reference, precision)) {
+        return this.createErrorMessage('before', parsed, {
+          ...options,
+          before: reference.format(errorFormat),
+        });
+      }
+    }
+
+    if (typeof options.onOrBefore !== 'undefined') {
+      const reference = getRelation('onOrBefore');
+
+      if (!parsed.isSameOrBefore(reference, precision)) {
+        return this.createErrorMessage('onOrBefore', parsed, {
+          ...options,
+          onOrBefore: reference.format(errorFormat),
+        });
+      }
+    }
+
+    if (typeof options.after !== 'undefined') {
+      const reference = getRelation('after');
+
+      if (!parsed.isAfter(reference, precision)) {
+        return this.createErrorMessage('after', parsed, {
+          ...options,
+          after: reference.format(errorFormat),
+        });
+      }
+    }
+
+    if (typeof options.onOrAfter !== 'undefined') {
+      const reference = getRelation('onOrAfter');
+
+      if (!parsed.isSameOrAfter(reference, precision)) {
+        return this.createErrorMessage('onOrAfter', parsed, {
+          ...options,
+          onOrAfter: reference.format(errorFormat),
+        });
+      }
+    }
+
+    return true;
+  },
 });

--- a/addon/validators/messages.js
+++ b/addon/validators/messages.js
@@ -22,4 +22,6 @@ import Messages from 'ember-validators/messages';
  *  @class Messages
  *  @module Validators
  */
-export default EmberObject.extend(Messages);
+export default EmberObject.extend(Messages, {
+  wrongDateFormat: '{description} must be in the format of {format}',
+});

--- a/package.json
+++ b/package.json
@@ -107,6 +107,9 @@
     "webpack": "^5.0.0",
     "yuidoc-ember-theme": "^2.0.1"
   },
+  "peerDependencies": {
+    "moment": "^2.29.4"
+  },
   "engines": {
     "node": "12.* || 14.* || >= 16"
   },

--- a/tests/unit/validators/date-test.js
+++ b/tests/unit/validators/date-test.js
@@ -112,6 +112,24 @@ module('Unit | Validator | date', function (hooks) {
     );
   });
 
+  ['before', 'onOrBefore', 'after', 'onOrAfter'].forEach((relation) => {
+    test(`options.${relation} - when not a date - validation raised`, function (assert) {
+      const values = ['', null, 'not a date'];
+      assert.expect(values.length);
+
+      values.forEach((value) => {
+        const opts = validator.buildOptions({ [relation]: value });
+        const message = validator.validate(moment(), opts);
+        assert.true(
+          typeof message === 'string',
+          `validation should fail when ${relation} is ${
+            value ? `${value}` : `"${value}"`
+          }`
+        );
+      });
+    });
+  });
+
   test('before', function (assert) {
     assert.expect(2);
 


### PR DESCRIPTION
Resolves https://github.com/adopted-ember-addons/ember-cp-validations/issues/723 .

Changes proposed:

 - reimplements the date validator that was removed in https://github.com/rwwagner90/ember-validators/pull/100/
 
I still think it would be better to support a consumer-defined "use luxon" or "use moment" or "use ___", or perhaps to propose an interface in which the consuming app can massage their preferred date library to support determining the before / onOrBefore / after / onOrAfter relationship states.
 - restores the test suite semantics from before https://github.com/adopted-ember-addons/ember-cp-validations/pull/715 (`git diff d6c95d741fa8388ae2c764037bddcd6c91691f09 tests/unit/validators/date-test.js`), while adding some additional tests / ensuring the test assertion messages help convey the test intent.

Tasks:

- [x] Added test case(s)
- [x] Updated documentation


cc: @fsmanuel for visibility