### PR TITLE
fix(computed): on Ember 4.12 / embroider v3

### DIFF
--- a/addon/-private/options.js
+++ b/addon/-private/options.js
@@ -4,6 +4,8 @@ import { isDescriptor } from '../utils/utils';
 const { keys } = Object;
 const OPTION_KEYS = '__option_keys__';
 
+const POSSIBLE_DECORATORS = ['AliasDecoratorImpl', 'ComputedDecoratorImpl'];
+
 const OptionsObject = EmberObject.extend({
   toObject() {
     return this[OPTION_KEYS].reduce((obj, key) => {
@@ -17,9 +19,15 @@ export default class Options {
   constructor({ model, attribute, options = {} }) {
     const optionKeys = keys(options);
     const createParams = { [OPTION_KEYS]: optionKeys, model, attribute };
+    const someOptionsAreCPs = optionKeys.some((key) => {
+      return (
+        isDescriptor(options[key]) ||
+        POSSIBLE_DECORATORS.includes(options[key]?.constructor?.name)
+      );
+    });
 
     // If any of the options is a CP, we need to create a custom class for it
-    if (optionKeys.some((key) => isDescriptor(options[key]))) {
+    if (someOptionsAreCPs) {
       return OptionsObject.extend(options).create(createParams);
     }
 


### PR DESCRIPTION
Resolves #733

Changes proposed:

 - Currently, if any of the `options` is a CP, we create a custom class for it
 - But the current code ignores `computed` decorators like `AliasDecoratorImpl` (constructor name) in which case the Error `"EmberObject.create no longer supports computed..."` is still thrown. This is happening on an ember-addon v1 on Ember 4.12 during the embroider-safe scenario (embroider v3)
 - This PR is meant to handle all possible scenarios where a property is either a "traditional" computed property or a computed "decorator" property.

Tasks:

- [ ] Added test case(s)
- [ ] Updated documentation
