### PR TITLE
Replace require with @embroider/macros

### DIFF
--- a/addon/utils/utils.js
+++ b/addon/utils/utils.js
@@ -4,15 +4,16 @@ import { isHTMLSafe } from '@ember/template';
 import EmberObject from '@ember/object';
 import { typeOf } from '@ember/utils';
 import { A as emberArray, isArray } from '@ember/array';
-import require from 'require';
+import {
+  macroCondition,
+  dependencySatisfies,
+  importSync,
+} from '@embroider/macros';
 
-function requireModule(module, exportName = 'default') {
-  if (require.has(module)) {
-    return require(module)[exportName];
-  }
+let DS;
+if (macroCondition(dependencySatisfies('ember-data', '*'))) {
+  DS = importSync('ember-data').default;
 }
-
-const DS = requireModule('ember-data');
 
 export { getDependentKeys, isDescriptor } from '../-private/ember-internals';
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
+    "@embroider/macros": "^1.13.2",
     "ember-cli-babel": "^7.26.11",
     "ember-validators": "^4.1.1"
   },
@@ -109,6 +110,14 @@
   },
   "peerDependencies": {
     "ember-source": "^4.0.0"
+  },
+  "peerDependencies": {
+    "ember-data": "*"
+  },
+  "peerDependenciesMeta": {
+    "ember-data": {
+      "optional": true
+    }
   },
   "engines": {
     "node": "14.* || 16.* || >= 18"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1510,12 +1510,41 @@
     resolve "^1.20.0"
     semver "^7.3.2"
 
+"@embroider/macros@^1.13.2":
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-1.13.2.tgz#07dda11313a2539f403404881b729e622a80ca17"
+  integrity sha512-AUgJ71xG8kjuTx8XB1AQNBiebJuXRfhcHr318dCwnQz9VRXdYSnEEqf38XRvGYIoCvIyn/3c72LrSwzaJqknOA==
+  dependencies:
+    "@embroider/shared-internals" "2.5.0"
+    assert-never "^1.2.1"
+    babel-import-util "^2.0.0"
+    ember-cli-babel "^7.26.6"
+    find-up "^5.0.0"
+    lodash "^4.17.21"
+    resolve "^1.20.0"
+    semver "^7.3.2"
+
 "@embroider/shared-internals@2.1.0", "@embroider/shared-internals@^2.0.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@embroider/shared-internals/-/shared-internals-2.1.0.tgz#4da79fe8b26e4b94819b8313c51b5b24a68c617b"
   integrity sha512-9hKbMxW7wDWt1BqdpnLZ5W6ETrmAg9HnfBwf1IDkT+8he5nOdTD0PNtruMjm7V0Tb9p9hI7O+UXSa8ZnX1BQXg==
   dependencies:
     babel-import-util "^1.1.0"
+    ember-rfc176-data "^0.3.17"
+    fs-extra "^9.1.0"
+    js-string-escape "^1.0.1"
+    lodash "^4.17.21"
+    resolve-package-path "^4.0.1"
+    semver "^7.3.5"
+    typescript-memoize "^1.0.1"
+
+"@embroider/shared-internals@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@embroider/shared-internals/-/shared-internals-2.5.0.tgz#4a0b5127c589718fae60fc22f81374ed558b944a"
+  integrity sha512-7qzrb7GVIyNqeY0umxoeIvjDC+ay1b+wb2yCVuYTUYrFfLAkLEy9FNI3iWCi3RdQ9OFjgcAxAnwsAiPIMZZ3pQ==
+  dependencies:
+    babel-import-util "^2.0.0"
+    debug "^4.3.2"
     ember-rfc176-data "^0.3.17"
     fs-extra "^9.1.0"
     js-string-escape "^1.0.1"
@@ -2912,6 +2941,11 @@ babel-import-util@^1.1.0, babel-import-util@^1.2.2, babel-import-util@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/babel-import-util/-/babel-import-util-1.3.0.tgz#dc9251ea39a7747bd586c1c13b8d785a42797f8e"
   integrity sha512-PPzUT17eAI18zn6ek1R3sB4Krc/MbnmT1MkZQFmyhjoaEGBVwNABhfVU9+EKcDSKrrOm9OIpGhjxukx1GCiy1g==
+
+babel-import-util@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/babel-import-util/-/babel-import-util-2.0.1.tgz#263a2963ee9208428c04f05326c6ea32b2206ac6"
+  integrity sha512-N1ZfNprtf/37x0R05J0QCW/9pCAcuI+bjZIK9tlu0JEkwEST7ssdD++gxHRbD58AiG5QE5OuNYhRoEFsc1wESw==
 
 babel-loader@^8.0.6:
   version "8.2.5"


### PR DESCRIPTION
In order to place nicely with Embroider, we need to remove `require`. Instead we can use `dependencySatisfies` and `importSync`.

Resolves #740

Changes proposed:
 - Remove `require` and replace with `dependencySatisfies` and `importSync`. ([docs](https://github.com/embroider-build/embroider/tree/main/packages/macros#dependencysatisfies))

Tasks:

N/A
