### PR TITLE
update @embroider/test-setup to fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,8 @@ jobs:
           - ember-release
           - ember-beta
           - ember-canary
-          # - embroider-safe
-          # - embroider-optimized
+          - embroider-safe
+          - embroider-optimized
 
     steps:
       - uses: actions/checkout@v4

--- a/addon/-private/options.js
+++ b/addon/-private/options.js
@@ -1,5 +1,4 @@
 import EmberObject, { get } from '@ember/object';
-import { isDescriptor } from '../utils/utils';
 
 const { keys } = Object;
 const OPTION_KEYS = '__option_keys__';
@@ -18,11 +17,7 @@ export default class Options {
     const optionKeys = keys(options);
     const createParams = { [OPTION_KEYS]: optionKeys, model, attribute };
 
-    // If any of the options is a CP, we need to create a custom class for it
-    if (optionKeys.some((key) => isDescriptor(options[key]))) {
-      return OptionsObject.extend(options).create(createParams);
-    }
-
-    return OptionsObject.create(createParams, options);
+    // we have to extend here in case anyone passes options that have computedProperties.
+    return OptionsObject.extend(options).create(createParams);
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@ember/optional-features": "^2.0.0",
     "@ember/string": "^3.0.1",
     "@ember/test-helpers": "^2.9.3",
-    "@embroider/test-setup": "^2.1.1",
+    "@embroider/test-setup": "^3.0.2",
     "@fortawesome/ember-fontawesome": "^1.0.0",
     "@fortawesome/fontawesome-svg-core": "^6.5.1",
     "@fortawesome/free-brands-svg-icons": "^6.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,8 +32,8 @@ devDependencies:
     specifier: ^2.9.3
     version: 2.9.4(ember-source@4.12.4)
   '@embroider/test-setup':
-    specifier: ^2.1.1
-    version: 2.1.1
+    specifier: ^3.0.2
+    version: 3.0.3
   '@fortawesome/ember-fontawesome':
     specifier: ^1.0.0
     version: 1.0.3(webpack@5.90.3)
@@ -1832,9 +1832,20 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@embroider/test-setup@2.1.1:
-    resolution: {integrity: sha512-t81a2z2OEFAOZVbV7wkgiDuCyZ3ajD7J7J+keaTfNSRiXoQgeFFASEECYq1TCsH8m/R+xHMRiY59apF2FIeFhw==}
+  /@embroider/test-setup@3.0.3:
+    resolution: {integrity: sha512-3K5KSyTdnxAkZQill6+TdC/XTRr6226LNwZMsrhRbBM0FFZXw2D8qmJSHPvZLheQx3A1jnF9t1lyrAzrKlg6Yw==}
     engines: {node: 12.* || 14.* || >= 16}
+    peerDependencies:
+      '@embroider/compat': ^3.3.0
+      '@embroider/core': ^3.4.0
+      '@embroider/webpack': ^3.2.1
+    peerDependenciesMeta:
+      '@embroider/compat':
+        optional: true
+      '@embroider/core':
+        optional: true
+      '@embroider/webpack':
+        optional: true
     dependencies:
       lodash: 4.17.21
       resolve: 1.22.8


### PR DESCRIPTION
The `@embroider/test-setup` package was very out of date so we really couldn't expect the `embroider-safe` or `embroider-optimised` tests to pass without updating it 👍 