### PR TITLE
add no-deprecations ember-try scenario

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
           - ember-canary
           - embroider-safe
           - embroider-optimized
+          - no-deprecations
 
     steps:
       - uses: actions/checkout@v4

--- a/tests/dummy/config/ember-try.js
+++ b/tests/dummy/config/ember-try.js
@@ -75,6 +75,14 @@ module.exports = async function () {
       },
       embroiderSafe(),
       embroiderOptimized(),
+      {
+        name: 'no-deprecations',
+        npm: {
+          devDependencies: {
+            'ember-deprecation-error': '*',
+          },
+        },
+      },
     ],
   };
 };


### PR DESCRIPTION
This is using https://github.com/mansona/ember-deprecation-error to try to get a better error message to see why the `ember-release` job is actually failing